### PR TITLE
Improved Memory Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@
 ## Description
 
 PHP library to parse PDF documents.
-
 The initial source code has been derived from [TCPDF](<http://www.tcpdf.org>).
+
+Forked by Ted Phillips (vaultwiki) in 2017 because the original library uses too much memory for large files and results are unreliable when the file size exceeds pcre.backtrack_limit. In the original, a sample 40MB PDF required over 250MB system memory to parse; the entire PDF was being loaded into memory and duplicated several times. This fork instead parses the file in chunks of 1KB or lower. After parsing, the peak memory usage for our sample file was less than 5% of its actual file size.
 
 
 ## Getting started

--- a/src/Process/RawObject.php
+++ b/src/Process/RawObject.php
@@ -50,12 +50,29 @@ abstract class RawObject
         // \x0C form feed (FF)
         // \x0D carriage return (CR)
         // \x20 space (SP)
-        $offset += strspn($this->pdfdata, "\x00\x09\x0a\x0c\x0d\x20", $offset);
+		fseek($this->pdf, $offset);
+		$block = fread($this->pdf, 1024);
+
+		while (($length = strspn($block, "\x00\x09\x0a\x0c\x0d\x20")) == 1024)
+		{
+			$offset += 1024;
+			$block = fread($this->pdf, 1024);
+		}
+
+		$offset += $length;
+		$block = substr($block, $length) . fread($this->pdf, 1024);
+
         // get first char
-        $char = $this->pdfdata[$offset];
+        $char = $block{0};
         if ($char == '%') { // \x25 PERCENT SIGN
             // skip comment and search for next token
-            $next = strcspn($this->pdfdata, "\r\n", $offset);
+			$next = 0;
+			while (($length = strcspn($block, "\r\n")) == 1024)
+			{
+				$next += 1024;
+				$block = fread($this->pdf, 1024);
+			}
+			$next += $length;
             if ($next > 0) {
                 $offset += $next;
                 return $this->getRawObject($offset);
@@ -74,10 +91,9 @@ abstract class RawObject
         if (isset($map[$char])) {
             $method = 'process'.$map[$char];
             $this->$method($char, $offset, $objtype, $objval);
-        } else {
-            if ($this->processDefaultName($offset, $objtype, $objval) === false) {
-                $this->processDefault($offset, $objtype, $objval);
-            }
+
+        } else if ($this->processDefaultName($offset, $objtype, $objval) === false) {
+			$this->processDefault($offset, $objtype, $objval);
         }
         return array($objtype, $objval, $offset);
     }
@@ -95,12 +111,14 @@ abstract class RawObject
     {
         $objtype = $char;
         ++$offset;
+		fseek($this->pdf, $offset);
+		$block = fread($this->pdf, 256);
+
         if (preg_match(
             '/^([^\x00\x09\x0a\x0c\x0d\x20\s\x28\x29\x3c\x3e\x5b\x5d\x7b\x7d\x2f\x25]+)/',
-            substr($this->pdfdata, $offset, 256),
+            $block,
             $matches
-        ) == 1
-        ) {
+        ) == 1) {
             $objval = $matches[1]; // unescaped value
             $offset += strlen($objval);
         }
@@ -119,14 +137,28 @@ abstract class RawObject
     {
         $objtype = $char;
         ++$offset;
-        $strpos = $offset;
+        $strpos = 0;
+		$totpos = 0;
+
         if ($char == '(') {
+			$newval = '';
             $open_bracket = 1;
+			fseek($this->pdf, $offset);
+			$block = fread($this->pdf, 1024);
+
             while ($open_bracket > 0) {
-                if (!isset($this->pdfdata[$strpos])) {
-                    break;
+                if (!isset($block[$strpos])) {
+					$newval .= $block;
+					$block = fread($this->pdf, 1024);
+					$totpos += $strpos;
+					$strpos = 0;
+
+					if (!isset($block[0]))
+					{
+	                    break;
+					}
                 }
-                $chr = $this->pdfdata[$strpos];
+                $chr = $block[$strpos];
                 switch ($chr) {
                     case '\\':
                         // REVERSE SOLIDUS (5Ch) (Backslash)
@@ -144,8 +176,8 @@ abstract class RawObject
                 }
                 ++$strpos;
             }
-            $objval = substr($this->pdfdata, $offset, ($strpos - $offset - 1));
-            $offset = $strpos;
+            $objval = $newval . substr($block, 0, $strpos - 1);
+            $offset += $totpos + $strpos;
         }
     }
 
@@ -169,6 +201,12 @@ abstract class RawObject
             do {
                 // get element
                 $element = $this->getRawObject($offset);
+
+				if (!$element[0])
+				{
+					break;
+				}
+
                 $offset = $element[2];
                 $objval[] = $element;
             } while ($element[0] != ']');
@@ -187,7 +225,10 @@ abstract class RawObject
      */
     protected function processAngular($char, &$offset, &$objtype, &$objval)
     {
-        if (isset($this->pdfdata[($offset + 1)]) && ($this->pdfdata[($offset + 1)] == $char)) {
+		fseek($this->pdf, $offset);
+		$block = fread($this->pdf, 2);
+
+        if (isset($block{1}) && ($block{1} == $char)) {
             // dictionary object
             $objtype = $char.$char;
             $offset += 2;
@@ -197,8 +238,16 @@ abstract class RawObject
                 do {
                     // get element
                     $element = $this->getRawObject($offset);
+
+					if (!$element[0])
+					{
+						// EOF
+						break;
+					}
+
                     $offset = $element[2];
                     $objval[] = $element;
+
                 } while ($element[0] != '>>');
                 // remove closing delimiter
                 array_pop($objval);
@@ -206,19 +255,70 @@ abstract class RawObject
         } else {
             // hexadecimal string object
             $objtype = $char;
+
             ++$offset;
-            if (($char == '<')
-                && (preg_match(
-                    '/^([0-9A-Fa-f\x09\x0a\x0c\x0d\x20]+)>/iU',
-                    substr($this->pdfdata, $offset),
-                    $matches
-                ) == 1)
-                ) {
-                // remove white space characters
-                $objval = strtr($matches[1], "\x09\x0a\x0c\x0d\x20", '');
-                $offset += strlen($matches[0]);
-            } elseif (($endpos = strpos($this->pdfdata, '>', $offset)) !== false) {
-                $offset = $endpos + 1;
+			$opening = false;
+			$endpos = strpos($block, '>', 1);
+			$offpos = 0;
+			$failed = false;
+
+			while ($endpos === false)
+			{
+				$block = fread($this->pdf, 1024);
+				$endpos = strpos($block, '>');
+				$blen = strlen($block);
+
+				if ($endpos === false)
+				{
+					$offpos += $blen;
+				}
+				if ($blen < 1024)
+				{
+					break;
+				}
+			}
+
+			if ($endpos !== false)
+			{
+				$endpos += $offpos;
+			}
+
+            if ($char == '<' AND $endpos)
+			{
+				fseek($this->pdf, $offset);
+				$tagcontents = fread($this->pdf, $endpos);
+				$tagcontents = str_split($tagcontents, 1024);
+				$newval = '';
+				$newset = 0;
+
+				foreach ($tagcontents AS $tagchunk)
+				{
+					if (preg_match(
+						'/^([0-9A-Fa-f\x09\x0a\x0c\x0d\x20]+)$/iU',
+						$tagchunk,
+						$matches
+        			) != 1)
+                	{
+						$failed = true;
+						break;
+					}
+
+	                // remove white space characters
+                	$newval .= strtr($matches[1], "\x09\x0a\x0c\x0d\x20", '');
+					$newset += strlen($matches[0]);
+				}
+				unset($tagcontents);
+
+				if (!$failed)
+				{
+					$objval = $newval;
+					$offset += $newset;
+					$opening = true;
+				}
+            }
+
+			if (!$opening AND $endpos !== false) {
+                $offset += $endpos;
             }
         }
     }
@@ -235,47 +335,89 @@ abstract class RawObject
     protected function processDefaultName(&$offset, &$objtype, &$objval)
     {
         $status = false;
-        if (substr($this->pdfdata, $offset, 6) == 'endobj') {
+		fseek($this->pdf, $offset);
+		$delimiter = fread($this->pdf, 9);
+
+        if (substr($delimiter, 0, 6) == 'endobj') {
             // indirect object
             $objtype = 'endobj';
             $offset += 6;
             $status = true;
-        } elseif (substr($this->pdfdata, $offset, 4) == 'null') {
+        } elseif (substr($delimiter, 0, 4) == 'null') {
             // null object
             $objtype = 'null';
             $offset += 4;
             $objval = 'null';
             $status = true;
-        } elseif (substr($this->pdfdata, $offset, 4) == 'true') {
+        } elseif (substr($delimiter, 0, 4) == 'true') {
             // boolean true object
             $objtype = 'boolean';
             $offset += 4;
             $objval = 'true';
             $status = true;
-        } elseif (substr($this->pdfdata, $offset, 5) == 'false') {
+        } elseif (substr($delimiter, 0, 5) == 'false') {
             // boolean false object
             $objtype = 'boolean';
             $offset += 5;
             $objval = 'false';
             $status = true;
-        } elseif (substr($this->pdfdata, $offset, 6) == 'stream') {
+        } elseif (substr($delimiter, 0, 6) == 'stream') {
             // start stream object
             $objtype = 'stream';
             $offset += 6;
-            if (preg_match('/^([\r]?[\n])/isU', substr($this->pdfdata, $offset), $matches) == 1) {
-                $offset += strlen($matches[0]);
-                if (preg_match(
-                    '/(endstream)[\x09\x0a\x0c\x0d\x20]/isU',
-                    substr($this->pdfdata, $offset),
-                    $matches,
-                    PREG_OFFSET_CAPTURE
-                ) == 1) {
-                    $objval = substr($this->pdfdata, $offset, $matches[0][1]);
-                    $offset += $matches[1][1];
-                }
+			fseek($this->pdf, $offset);
+			$block = fread($this->pdf, 1024);
+
+            if ($block)
+			{
+				$stream_started = false;
+				$startset = 0;
+
+				if ($block{0} == "\n")
+				{
+					$stream_started = true;
+					$offset += 1;
+					$startset = 1;
+				}
+				else if (isset($block{1}) AND $block{0} . $block{1} == "\r\n")
+				{
+					$stream_started = true;
+					$offset += 2;
+					$startset = 2;
+				}
+
+				if ($stream_started)
+				{
+					$stopset = strpos($block, 'endstream');
+					$rounds = 0;
+
+					while ($stopset === false AND strlen($block) == 1024)
+					{
+						$block = fread($this->pdf, 1024);
+						$stopset = strpos($block, 'endstream');
+
+						if ($stopset === false)
+						{
+							$stopset += 1024;
+						}
+					}
+
+					if ($stopset !== false)
+					{
+						$char = substr($block, $stopset + 9, 1);
+
+						if (preg_match('/[\x09\x0a\x0c\x0d\x20]/', $char, $m))
+						{
+							fseek($this->pdf, $offset);
+		                    $objval = fread($this->pdf, $stopset + $rounds - $startset);
+							$offset += 10;
+		       	        }
+					}
+				}
             }
+			unset($stream_data);
             $status = true;
-        } elseif (substr($this->pdfdata, $offset, 9) == 'endstream') {
+        } elseif ($delimiter == 'endstream') {
             // end stream object
             $objtype = 'endstream';
             $offset += 9;
@@ -293,9 +435,11 @@ abstract class RawObject
      */
     protected function processDefault(&$offset, &$objtype, &$objval)
     {
+		fseek($this->pdf, $offset);
+		$thirtythree = fread($this->pdf, 33);
         if (preg_match(
             '/^([0-9]+)[\s]+([0-9]+)[\s]+R/iU',
-            substr($this->pdfdata, $offset, 33),
+            $thirtythree,
             $matches
         ) == 1) {
             // indirect object reference
@@ -304,18 +448,41 @@ abstract class RawObject
             $objval = intval($matches[1]).'_'.intval($matches[2]);
         } elseif (preg_match(
             '/^([0-9]+)[\s]+([0-9]+)[\s]+obj/iU',
-            substr($this->pdfdata, $offset, 33),
+            $thirtythree,
             $matches
         ) == 1) {
             // object start
             $objtype = 'obj';
             $objval = intval($matches[1]).'_'.intval($matches[2]);
             $offset += strlen($matches[0]);
-        } elseif (($numlen = strspn($this->pdfdata, '+-.0123456789', $offset)) > 0) {
-            // numeric object
-            $objtype = 'numeric';
-            $objval = substr($this->pdfdata, $offset, $numlen);
-            $offset += $numlen;
+        } else {
+			$numlen = strspn($thirtythree, '+-.0123456789');
+			if ($numlen)
+			{
+				$newval = substr($thirtythree, 0, $numlen);
+
+				if ($numlen == 33)
+				{
+					$block = fread($this->pdf, 1024);
+
+					while (($length = strspn($block, '+-.0123456789')) === 1024) {
+						$newval .= $block;
+						$block = fread($this->pdf, 1024);
+						$numlen += 1024;
+					}
+
+					if ($length)
+					{
+						$numlen += $length;
+						$newval .= substr($block, 0, $length);
+					}
+				}
+
+		        // numeric object
+		        $objtype = 'numeric';
+				$objval = $newval;
+		        $offset += $numlen;
+			}
         }
     }
 }


### PR DESCRIPTION
This set of updates dramatically reduces memory usage while parsing. In one test, usage went from 500% file size to 5% file size.

These changes also fix the inability to parse some files or file portions that were longer than pcre.backtrack_limit.

The fix parses blocks of files 1024 bytes at a time. Perhaps this can be made into one of the config options, so someone can use blocks of 4096 or more if desired. If the config option becomes configurable, it should always be forced to lower than pcre.backtrack_limit. In PHP < 5.3.7, the default limit was 100,000. In PHP >= 5.3.7, the default was 1,000,000, still lower than many PDF lengths. Even if a custom ini is -1 or higher than 1,000,000, it is probably best to force block sizes lower than the pre-5.3.7 default.

The first __construct argument $pdfhandle represents a file resource created by using fopen($pdfpath, 'rb'). It is expected that the caller will still need access to the resource in order to make use of any of the parsed information, so there is no __destruct here that automatically closes it. fopen and fclose shall be the responsibility of the caller.